### PR TITLE
Potential fix for code scanning alert no. 3: Bad HTML filtering regexp

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -111,7 +111,7 @@ function removeCommentTags(code: string) {
 		.replace(/\/\/(.*)$/gm, '$1') // Menghapus // dan menyimpan teks setelahnya
 		.replace(/\/\*[\s\S]*?\*\//g, '') // Menghapus komentar multi-baris
 		.replace(/#(.*)$/gm, '$1') // Menghapus # dan menyimpan teks setelahnya
-		.replace(/<!--(.*?)-->/g, '$1') // Menghapus komentar HTML
+		.replace(/<!--([\s\S]*?)-->/g, '$1') // Menghapus komentar HTML, termasuk yang multi-baris
 		.replace(/\n\s*\n/g, '\n') // Menghapus baris kosong yang tersisa
 		.trim(); // Menghapus spasi di awal dan akhir
 }


### PR DESCRIPTION
Potential fix for [https://github.com/faizinuha/Meiko/security/code-scanning/3](https://github.com/faizinuha/Meiko/security/code-scanning/3)

To fix the issue, the regular expression for matching HTML comments should be updated to handle multi-line comments. This can be achieved by replacing `<!--(.*?)-->` with `<!--([\s\S]*?)-->`. The `[\s\S]` pattern matches any character, including newlines, ensuring that multi-line comments are correctly matched and removed.

The change should be made in the `removeCommentTags` function, specifically on line 114. No additional imports or dependencies are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
